### PR TITLE
Update to assign xDomainCookie to window object

### DIFF
--- a/dist/xdomaincookie.js
+++ b/dist/xdomaincookie.js
@@ -277,3 +277,5 @@ xDomainCookie.host.init = function (callback) {
         }
     });
 };
+
+window.xDomainCookie = xDomainCookie;


### PR DESCRIPTION
This will save issues in other environments.
If you import it in any project, it'll add the functionality to window without needing an angular factory from cooperative for that.